### PR TITLE
JavaFX lib verwijderd van Build Path

### DIFF
--- a/HR/.classpath
+++ b/HR/.classpath
@@ -13,6 +13,5 @@
 	<classpathentry kind="lib" path="hibernatelib/jboss-logging-3.3.0.Final.jar"/>
 	<classpathentry kind="lib" path="hibernatelib/jboss-transaction-api_1.2_spec-1.0.1.Final.jar"/>
 	<classpathentry kind="lib" path="hibernatelib/mysql-connector-java-5.1.44-bin.jar"/>
-	<classpathentry kind="con" path="org.eclipse.fx.ide.jdt.core.JAVAFX_CONTAINER"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
JavaFX JARs zitten al in standaard JRE